### PR TITLE
clarify that this is not a community owned or maintained plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![Build Status](https://travis-ci.org/obazoud/sensu-plugins-kafka.svg?branch=master)](https://travis-ci.org/obazoud/sensu-plugins-kafka) [![Gem Version](https://badge.fury.io/rb/sensu-plugins-kafka.svg)](https://badge.fury.io/rb/sensu-plugins-kafka)
 
+## Community Status
+
+This plugin is not officially supporting this plugin please see https://github.com/sensu-plugins/sensu-plugins-kafka for the officially maintained community plugin.
+
 ## Functionality
 
 **check-consumer-lag.rb**

--- a/sensu-plugins-kafka.gemspec
+++ b/sensu-plugins-kafka.gemspec
@@ -10,14 +10,14 @@ else
 end
 
 Gem::Specification.new do |s|
-  s.authors                = ['Sensu-Plugins and contributors']
+  s.authors                = ['Olivier Bazoud and contributors']
   s.cert_chain             = ['certs/sensu-plugins.pem']
   s.date                   = Date.today.to_s
-  s.description            = 'Sensu plugins for Kafka'
-  s.email                  = '<sensu-users@googlegroups.com>'
+  s.description            = 'Non Community Sensu plugins for Kafka'
+  s.email                  = 'olivier.bazoud@gmail.com'
   s.executables            = Dir.glob('bin/**/*').map { |file| File.basename(file) }
   s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
-  s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-kafka'
+  s.homepage               = 'https://github.com/obazoud/sensu-plugins-kafka'
   s.license                = 'MIT'
   s.metadata               = { 'maintainer'         => 'sensu-plugin',
                                'development_status' => 'active',


### PR DESCRIPTION
Basically this gem implies that it is a community plugin see #21 for details. As I have not heard back on it I am gonna end up renaming the existing repo to `sensu-plugins-kafka2` to avoid namespace conflict but in case you would like to merge this that would be greatly appreciated.


Signed-off-by: Ben Abrams <me@benabrams.it>